### PR TITLE
fix: wrong gtest_filter parameter

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -63,7 +63,7 @@ export const GlobalVars = {
 
       args = args.map(escapeCatch2Chars);
     } else if (voteTokenType.maxVoteTokenType === "gtest") {
-      args = args.map((arg) => `--gtest_filter='*${arg}*'`);
+      args = args.map((arg) => `--gtest_filter=*${arg}*`);
     }
 
     return args;


### PR DESCRIPTION
I discovered that passing the label within a single quote makes GTest confused and not start any test.
It would be better to pass the filter using the `GTEST_FILTER` env variable but this is a good enough.