### PR TITLE
Add a configuration item for the debug command type

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,18 @@
         "enablement": "false",
         "title": "Get Test Param"
       }
+    ],
+    "configuration": [
+      {
+        "title": "CMake Test Tools",
+        "properties": {
+          "cmake-test-tools.debugType": {
+            "type": "string",
+            "default": "lldb",
+            "markdownDescription": "The type for debug command."
+          }
+        }
+      }
     ]
   },
   "scripts": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as vscode from "vscode";
-import { Commands, GlobalVars } from "./constant";
+import { Commands, Configurations, EXTENSION_NAME, GlobalVars } from "./constant";
 import { runCommand } from "./terminal";
 import { TestCase } from "./parser";
 import * as fs from "fs";
@@ -46,8 +46,9 @@ export async function runTest(testCase?: TestCase) {
 
 export function debugTest(testCase?: TestCase) {
   GlobalVars.currentTestCase = testCase;
+  let configuration = vscode.workspace.getConfiguration(EXTENSION_NAME);
   vscode.debug.startDebugging(undefined, {
-    type: "lldb",
+    type: configuration.get(Configurations.DebugType) ?? "lldb",
     request: "launch",
     name: "Debug CMake Target Test",
     program: "${command:cmake.launchTargetPath}",

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -12,6 +12,10 @@ export enum Commands {
   GetTestParam = "cmake-test-tools.getTestParam",
 }
 
+export enum Configurations {
+  DebugType = "debugType",
+}
+
 export const GlobalVars = {
   currentTestCase: undefined as TestCase | undefined,
   getTestArgs(shouldEscape = true): string[] {


### PR DESCRIPTION
We can use other debug tools instead of codelldb, like [LLDB DAP](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap).